### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix supply chain vulnerability by pinning base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Use a specific version of the Jupyter notebook stack for reproducibility.
 # Images are now hosted on quay.io
-FROM quay.io/jupyter/minimal-notebook:python-3.11.6
+# Pinned to specific sha256 digest to prevent supply chain attacks
+FROM quay.io/jupyter/minimal-notebook@sha256:25ad099a1eafc1bcdd0c0868f4d4f93264a1c1885bdee0a4c58840ed108cfa24
 
 # Install PyTorch, torchvision, and other dependencies using conda.
 # Using a specific CUDA version for consistency.


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `Dockerfile` used a mutable base image tag (`quay.io/jupyter/minimal-notebook:python-3.11.6`). If an attacker were to compromise the `quay.io` account and push a malicious image to this tag, the build process would unknowingly execute the malicious code, leading to a supply chain attack.
🎯 **Impact:** Compromised Docker container with potential data exfiltration, unauthorized access to the host machine, or lateral movement within the network.
🔧 **Fix:** Replaced the mutable tag with the specific, immutable SHA256 digest of the current image (`quay.io/jupyter/minimal-notebook@sha256:25ad099a1eafc1bcdd0c0868f4d4f93264a1c1885bdee0a4c58840ed108cfa24`). Added a comment explaining the security rationale.
✅ **Verification:** Run `docker build -t docker-mingpt .` and confirm that it attempts to build using the pinned digest.

---
*PR created automatically by Jules for task [10913030519954282726](https://jules.google.com/task/10913030519954282726) started by @partrita*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base image reference to use a pinned digest for improved reproducibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->