### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,10 @@ WORKDIR /home/jovyan/
 # Clone the minGPT repository directly into the container.
 # This makes the Docker build self-contained and not reliant on local files.
 # Checking out a specific commit for security and reproducibility
+# 🛡️ Sentinel: Disable git terminal prompts and add timeout to prevent build-time DoS if repo is inaccessible
 # Set the SHELL option -o pipefail before RUN with a pipe in it
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN git clone https://github.com/karpathy/minGPT.git && \
+RUN GIT_TERMINAL_PROMPT=0 timeout 300 git clone https://github.com/karpathy/minGPT.git && \
     cd minGPT && \
     git checkout 4050db60409b5bbaaa3302cee1e49847fc145c65
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Docker build process executes a `git clone` command without any timeout constraints or prompt disablement. If the remote repository becomes inaccessible or requires authentication unexpectedly, the build process could hang indefinitely, leading to resource exhaustion (a form of Denial of Service during build time in CI/CD pipelines).
🎯 Impact: This could lead to stuck CI/CD pipelines, consuming valuable build minutes and potentially preventing other critical builds from running.
🔧 Fix: Modified the `RUN` command in the `Dockerfile` to prepend `GIT_TERMINAL_PROMPT=0` and `timeout 300` to the `git clone` execution. This ensures the build fails fast (within 5 minutes) if the repository is unreachable and won't hang waiting for user input.
✅ Verification: Review the `Dockerfile` to ensure the new variables and command prefixes are in place. A local `docker build .` was run to ensure no syntactic regressions were introduced.

---
*PR created automatically by Jules for task [6666910443909389582](https://jules.google.com/task/6666910443909389582) started by @partrita*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build process reliability by implementing automatic timeout protection and suppressing interactive prompts to prevent build hangs and failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->