### PR TITLE
🛡️ Sentinel: [security improvement] Add timeout to git clone in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ WORKDIR /home/jovyan/
 # Checking out a specific commit for security and reproducibility
 # Set the SHELL option -o pipefail before RUN with a pipe in it
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN git clone https://github.com/karpathy/minGPT.git && \
+# 🛡️ Sentinel: Added timeout to git clone to prevent build-time DoS
+RUN timeout 120 git clone https://github.com/karpathy/minGPT.git && \
     cd minGPT && \
     git checkout 4050db60409b5bbaaa3302cee1e49847fc145c65
 


### PR DESCRIPTION
🚨 Severity: LOW (Enhancement)
💡 Vulnerability: Missing timeout on external network call (`git clone`) in Docker build process.
🎯 Impact: If the GitHub server hangs or becomes uncooperative, the Docker build process could hang indefinitely, leading to resource exhaustion or build-time Denial of Service (DoS).
🔧 Fix: Added a `timeout 120` to the `git clone` command in the `Dockerfile`.
✅ Verification: Ran a test build of the Docker image to verify that the `Dockerfile` syntax is still valid and the build starts correctly.

---
*PR created automatically by Jules for task [5366601982696671529](https://jules.google.com/task/5366601982696671529) started by @partrita*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added timeout protection to the build process to prevent indefinite operations during dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->