### PR TITLE
🛡️ Sentinel: [security improvement] Add timeout to external network calls in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ WORKDIR /home/jovyan/
 # Checking out a specific commit for security and reproducibility
 # Set the SHELL option -o pipefail before RUN with a pipe in it
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN git clone https://github.com/karpathy/minGPT.git && \
+# 🛡️ Sentinel: Added timeout to external network call to prevent build-time DoS
+RUN timeout 300 git clone https://github.com/karpathy/minGPT.git && \
     cd minGPT && \
     git checkout 4050db60409b5bbaaa3302cee1e49847fc145c65
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential build-time Denial of Service (DoS) due to hanging external network call (`git clone`).
🎯 Impact: If GitHub is unresponsive or deliberately slowed down, the Docker build process could hang indefinitely, tying up CI/CD resources.
🔧 Fix: Wrapped the `git clone` command with the `timeout` utility (300 seconds) to ensure the command fails fast if the remote server becomes unresponsive.
✅ Verification: Build the Docker image. If GitHub is reachable, it will build correctly. If the connection hangs for more than 5 minutes, it will fail securely.

---
*PR created automatically by Jules for task [12361059914273538657](https://jules.google.com/task/12361059914273538657) started by @partrita*