### PR TITLE
🛡️ Sentinel: [security improvement] Add HEALTHCHECK to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,10 @@ WORKDIR /home/jovyan/minGPT
 RUN wget -q --timeout=15 https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt -O /home/jovyan/minGPT/input.txt && \
     echo "86c4e6aa9db7c042ec79f339dcb96d42b0075e16b8fc2e86bf0ca57e2dc565ed  /home/jovyan/minGPT/input.txt" | sha256sum -c -
 
+# 🛡️ Sentinel: Added HEALTHCHECK to detect compromised or hanging container states
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD wget --quiet --tries=1 --spider http://localhost:8888/ || exit 1
+
 # The container will start JupyterLab by default.
 # To build this image, run:
 # docker build -t docker-mingpt .


### PR DESCRIPTION
🚨 Severity: LOW / ENHANCEMENT
💡 Vulnerability: Missing container health verification, which can lead to undetected hanging or compromised container states.
🎯 Impact: Container orchestrators cannot automatically detect and restart unresponsive containers, potentially leading to prolonged downtime during DoS attacks or application deadlocks.
🔧 Fix: Added a standard Docker `HEALTHCHECK` instruction using `wget --spider` to periodically ping the JupyterLab port (8888).
✅ Verification: Build the Docker image (`docker build -t docker-mingpt .`) and run the container (`docker run -p 8888:8888 docker-mingpt`). Use `docker ps` to verify the container status eventually shows as `(healthy)`.

---
*PR created automatically by Jules for task [2072219906545413403](https://jules.google.com/task/2072219906545413403) started by @partrita*