### PR TITLE
🛡️ Sentinel: [HIGH] Fix overly permissive Docker port exposure in docs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `Dockerfile` downloaded external dependencies (`git clone` of a repository and `wget` of a data file) without pinning specific versions or verifying their integrity using checksums. This presents a risk of supply chain attacks or unexpected build failures if the upstream files are modified.
 **Learning:** Even in educational or seemingly low-risk projects, external dependencies should be verified. Without verification, an attacker compromising the upstream source could inject malicious code or data that executes during the Docker build or when the container is run. The lack of checksums for downloaded files is a common pattern that can lead to compromised environments.
 **Prevention:** Always pin specific commits or tags when cloning repositories in `Dockerfile`s. Always use checksum validation (e.g., `sha256sum`) when downloading external files using tools like `wget` or `curl`.
+
+## 2024-05-24 - [Insecure Docker Port Binding]
+**Vulnerability:** The documentation instructed users to run the container using `docker run -p 8888:8888`. This binds the port to `0.0.0.0`, exposing the JupyterLab server (which allows remote code execution) to the entire local network, bypassing host firewalls like UFW. This poses a direct risk to the host infrastructure.
+**Learning:** Docker bypasses UFW by default. Binding to `0.0.0.0` is dangerous for development servers, especially those offering remote code execution like JupyterLab.
+**Prevention:** Always explicitly bind to localhost (`127.0.0.1`) when running containers intended for local access only, e.g., `docker run -p 127.0.0.1:8888:8888`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,5 @@ RUN wget -q --timeout=15 https://raw.githubusercontent.com/karpathy/char-rnn/mas
 # docker build -t docker-mingpt .
 #
 # To run the container:
-# docker run -p 8888:8888 docker-mingpt
+# docker run -p 127.0.0.1:8888:8888 docker-mingpt
 # Then open the URL printed in the console in your browser.

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ docker build -t docker-mingpt .
 Once the image is built, you can run it as a container with this command:
 
 ```bash
-docker run -p 8888:8888 docker-mingpt
+docker run -p 127.0.0.1:8888:8888 docker-mingpt
 ```
 
-This command starts the JupyterLab server inside the container and maps port 8888 of the container to port 8888 on your local machine.
+This command starts the JupyterLab server inside the container and maps port 8888 of the container to port 8888 on your local machine. 🛡️ Sentinel: By explicitly binding to `127.0.0.1`, we prevent the JupyterLab server (which allows remote code execution) from being exposed to the local network.
 
 ### 3. Access JupyterLab
 


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The documentation instructed users to run the container using `docker run -p 8888:8888`. This binds the port to `0.0.0.0`, exposing the JupyterLab server (which allows remote code execution) to the entire local network, bypassing host firewalls like UFW.
🎯 **Impact**: Anyone on the local network could connect to the JupyterLab server and execute arbitrary code on the host machine.
🔧 **Fix**: Updated the `README.md` and `Dockerfile` comments to instruct users to explicitly bind the port to localhost using `docker run -p 127.0.0.1:8888:8888 docker-mingpt`.
✅ **Verification**: Run `docker run -p 127.0.0.1:8888:8888 docker-mingpt` and verify it only binds to localhost.

---
*PR created automatically by Jules for task [308267439244903044](https://jules.google.com/task/308267439244903044) started by @partrita*

## Summary by Sourcery

Document and mitigate insecure Docker port exposure for the JupyterLab container.

Documentation:
- Update README to recommend binding JupyterLab’s Docker port to localhost (127.0.0.1) instead of all interfaces and explain the security rationale.
- Extend Sentinel security notes with a new entry describing the insecure Docker port binding vulnerability and its prevention.

Chores:
- Align Dockerfile usage comments with the secure localhost-only Docker run command.