### PR TITLE
🛡️ Sentinel: [security improvement] Add Dockerfile HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,3 +37,7 @@ RUN wget -q --timeout=15 https://raw.githubusercontent.com/karpathy/char-rnn/mas
 # To run the container:
 # docker run -p 8888:8888 docker-mingpt
 # Then open the URL printed in the console in your browser.
+
+# 🛡️ Sentinel: Added healthcheck to detect hung or crashed Jupyter server
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD wget -qO- http://localhost:8888 || exit 1


### PR DESCRIPTION
🚨 Severity: ENHANCEMENT
💡 Vulnerability: The Docker container lacked a healthcheck to determine if the Jupyter server inside the container was actually responsive or had crashed/hung.
🎯 Impact: Without a healthcheck, container orchestration tools (like Docker Swarm or Kubernetes) cannot automatically detect and recover from an unresponsive Jupyter server, potentially leading to prolonged DoS for users of the container environment.
🔧 Fix: Added a `HEALTHCHECK` instruction to the `Dockerfile` that uses `wget` to periodically verify the availability of the Jupyter service on port 8888.
✅ Verification: Build the Docker image and start a container. Run `docker inspect <container_id>` or `docker ps` to verify that the container reports a 'healthy' status.

---
*PR created automatically by Jules for task [10076669382772576138](https://jules.google.com/task/10076669382772576138) started by @partrita*