### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ WORKDIR /home/jovyan/
 # Checking out a specific commit for security and reproducibility
 # Set the SHELL option -o pipefail before RUN with a pipe in it
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN git clone https://github.com/karpathy/minGPT.git && \
+# 🛡️ Sentinel: Added timeout to external repository clone to prevent build-time DoS
+RUN timeout 300 git clone https://github.com/karpathy/minGPT.git && \
     cd minGPT && \
     git checkout 4050db60409b5bbaaa3302cee1e49847fc145c65
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External network calls during Docker build (`git clone`) without a timeout can hang indefinitely due to network issues or malicious upstream unresponsiveness.
🎯 Impact: This can cause a build-time Denial of Service (DoS) by monopolizing build server resources or causing CI pipelines to hang indefinitely.
🔧 Fix: Wrapped the `git clone` command in the `Dockerfile` with the GNU coreutils `timeout` utility set to 300 seconds (5 minutes) to ensure the network operation fails gracefully. Also added a contextual security comment.
✅ Verification: Ensure the `Dockerfile` builds without syntax errors. (Tested locally via `docker build -t docker-mingpt .`).

---
*PR created automatically by Jules for task [693253252254948739](https://jules.google.com/task/693253252254948739) started by @partrita*