### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /home/jovyan/
 # Checking out a specific commit for security and reproducibility
 # Set the SHELL option -o pipefail before RUN with a pipe in it
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN git clone https://github.com/karpathy/minGPT.git && \
+RUN timeout 120 git clone https://github.com/karpathy/minGPT.git && \
     cd minGPT && \
     git checkout 4050db60409b5bbaaa3302cee1e49847fc145c65
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing timeout configurations on external network calls (`git clone`) during the Docker build process.
🎯 **Impact:** If the external git server (GitHub) is unresponsive or connection hangs, the build process could stall indefinitely. This could lead to resource exhaustion and a Denial of Service (DoS) in CI/CD environments.
🔧 **Fix:** Wrapped the `git clone` command with a 120-second timeout (`timeout 120 git clone ...`). Since `minGPT` is a small repository, 120 seconds is sufficient for successful clones while providing a fail-fast mechanism in case of network issues.
✅ **Verification:** Verified that the syntax is correct and does not introduce regressions using the `hadolint` tool.

---
*PR created automatically by Jules for task [7072313862854623692](https://jules.google.com/task/7072313862854623692) started by @partrita*