### PR TITLE
🛡️ Sentinel: [security improvement] Dockerfile security enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ WORKDIR /home/jovyan/
 # Checking out a specific commit for security and reproducibility
 # Set the SHELL option -o pipefail before RUN with a pipe in it
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN git clone https://github.com/karpathy/minGPT.git && \
-    cd minGPT && \
-    git checkout 4050db60409b5bbaaa3302cee1e49847fc145c65
+RUN timeout 300 git clone https://github.com/karpathy/minGPT.git && \
+    git -C minGPT checkout 4050db60409b5bbaaa3302cee1e49847fc145c65 && \
+    rm -rf minGPT/.git
 
 # Set the working directory to the cloned repo.
 WORKDIR /home/jovyan/minGPT


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `Dockerfile` performed an external network call (`git clone`) without a timeout, risking a build-time Denial of Service (DoS) if the upstream server hangs. Additionally, the `.git` directory was left in the image, potentially leaking history/metadata and increasing the attack surface.
🎯 Impact: An attacker or network issue could cause the Docker build process to hang indefinitely. Leaving the `.git` directory unnecessarily exposes source control history within the final container.
🔧 Fix: Wrapped the `git clone` command with a `timeout 300` wrapper to fail fast if the connection hangs. Updated the `RUN` block to use `git -C` (avoiding `cd` to resolve a Hadolint `DL3003` warning) and added a command to remove the `minGPT/.git` directory after cloning to minimize the attack surface.
✅ Verification: Ran `hadolint` locally which passed without warnings. Ran `docker build .` (fails on sandbox infrastructure due to overlay mounts, but validates the syntax).

---
*PR created automatically by Jules for task [7491728725894681800](https://jules.google.com/task/7491728725894681800) started by @partrita*