### PR TITLE
🛡️ Sentinel: [security improvement] Add timeout to git clone to prevent build-time DoS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ WORKDIR /home/jovyan/
 # Checking out a specific commit for security and reproducibility
 # Set the SHELL option -o pipefail before RUN with a pipe in it
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN git clone https://github.com/karpathy/minGPT.git && \
+# 🛡️ Sentinel: Added timeout to external git clone to prevent build-time DoS (hanging connections)
+RUN timeout 120 git clone https://github.com/karpathy/minGPT.git && \
     cd minGPT && \
     git checkout 4050db60409b5bbaaa3302cee1e49847fc145c65
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unbounded external network calls during Docker build (`git clone` without timeout).
🎯 **Impact:** Potential build-time Denial of Service (DoS) or indefinitely hanging CI/CD pipelines if GitHub or network is unresponsive.
🔧 **Fix:** Added a 120-second timeout to the `git clone` command in the `Dockerfile`.
✅ **Verification:** Verify that `Dockerfile` contains `timeout 120 git clone` and run `docker build .` to ensure the syntax remains valid.

---
*PR created automatically by Jules for task [15861683405211912703](https://jules.google.com/task/15861683405211912703) started by @partrita*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Improved build reliability by adding timeout protection to external repository fetch operations, preventing indefinite hangs and ensuring faster build failure detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->