### PR TITLE
🛡️ Sentinel: [security improvement] Enforce non-root execution in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,11 @@ WORKDIR /home/jovyan/minGPT
 RUN wget -q --timeout=15 https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt -O /home/jovyan/minGPT/input.txt && \
     echo "86c4e6aa9db7c042ec79f339dcb96d42b0075e16b8fc2e86bf0ca57e2dc565ed  /home/jovyan/minGPT/input.txt" | sha256sum -c -
 
+# 🛡️ Sentinel: Explicitly drop privileges to the non-root user to enforce defense-in-depth.
+# This prevents the container from accidentally running as root if upstream base images
+# or earlier build steps are modified to use the root user.
+USER $NB_UID
+
 # The container will start JupyterLab by default.
 # To build this image, run:
 # docker build -t docker-mingpt .


### PR DESCRIPTION
🚨 **Severity**: LOW (Security Enhancement)
💡 **Vulnerability**: Potential privilege escalation. While the base Jupyter image currently runs as `jovyan` (`$NB_UID`), relying entirely on the upstream image to maintain this state introduces a risk. If upstream base images are modified, or if earlier build steps temporarily switch to the `root` user and forget to switch back, the resulting container could run as `root` by default.
🎯 **Impact**: Running the container as `root` violates the principle of least privilege. If the Jupyter environment or an underlying dependency were compromised, the attacker would gain `root` access within the container namespace, increasing the potential blast radius.
🔧 **Fix**: Explicitly added the `USER $NB_UID` instruction at the end of the `Dockerfile` to enforce defense-in-depth and guarantee the container drops privileges before execution.
✅ **Verification**: Run `docker run --rm docker-mingpt whoami` and ensure it outputs a non-root user (e.g., `jovyan`).

---
*PR created automatically by Jules for task [7298386556746222850](https://jules.google.com/task/7298386556746222850) started by @partrita*