### PR TITLE
🛡️ Sentinel: [security improvement] Add Dockerfile HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,3 +37,7 @@ RUN wget -q --timeout=15 https://raw.githubusercontent.com/karpathy/char-rnn/mas
 # To run the container:
 # docker run -p 8888:8888 docker-mingpt
 # Then open the URL printed in the console in your browser.
+
+# 🛡️ Sentinel: Added HEALTHCHECK to ensure the container is running securely and reliably
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD wget -qO- http://localhost:8888/ || exit 1


### PR DESCRIPTION
🚨 Severity: ENHANCEMENT
💡 Vulnerability: Missing container health monitoring. Without a HEALTHCHECK, Docker orchestration systems cannot accurately determine if the internal application (JupyterLab) has hung, become unresponsive, or entered a DoS condition, even if the container process itself remains running.
🎯 Impact: Improved operational security and reliability. Orchestration tools can now automatically detect unresponsiveness and restart or isolate the container as needed, mitigating application-level denial-of-service states.
🔧 Fix: Appended a `HEALTHCHECK` instruction to the `Dockerfile` that uses `wget` to periodically ping the JupyterLab server on port 8888. This configuration is aligned with CIS Docker Benchmark recommendations.
✅ Verification: The syntax of the `Dockerfile` has been successfully verified via a local build attempt (which passed structural parsing, bypassing the sandbox-specific execution limitation).

---
*PR created automatically by Jules for task [17100504529376819783](https://jules.google.com/task/17100504529376819783) started by @partrita*