### PR TITLE
🛡️ Sentinel: [security improvement] Remove security theater build timeout

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,8 @@
 **Vulnerability:** The documentation instructed users to run the container using `docker run -p 8888:8888`. This binds the port to `0.0.0.0`, exposing the JupyterLab server (which allows remote code execution) to the entire local network, bypassing host firewalls like UFW. This poses a direct risk to the host infrastructure.
 **Learning:** Docker bypasses UFW by default. Binding to `0.0.0.0` is dangerous for development servers, especially those offering remote code execution like JupyterLab.
 **Prevention:** Always explicitly bind to localhost (`127.0.0.1`) when running containers intended for local access only, e.g., `docker run -p 127.0.0.1:8888:8888`.
+
+## 2024-05-24 - [Security Theater in Build Timeouts]
+**Vulnerability:** Adding hardcoded timeouts to heavy build steps (like `git clone`) in a Dockerfile as a preventative measure against DoS or hanging builds.
+**Learning:** Hardcoding timeouts for large operations in a Dockerfile introduces build flakiness and is often considered "security theater." CI/CD systems and build environments natively handle overall task and job timeouts more robustly. Attempting to manage this at the individual command level within a Dockerfile is an anti-pattern unless the command is known to hang indefinitely by design.
+**Prevention:** Rely on the native timeout mechanisms of the build environment or CI/CD runner rather than implementing brittle, hardcoded timeouts within the Dockerfile itself.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ WORKDIR /home/jovyan/
 # Clone the minGPT repository directly into the container.
 # This makes the Docker build self-contained and not reliant on local files.
 # Checking out a specific commit for security and reproducibility
-# 🛡️ Sentinel: Disable git terminal prompts and add timeout to prevent build-time DoS if repo is inaccessible
+# 🛡️ Sentinel: Disable git terminal prompts to prevent build-time hangs if repo is inaccessible
 # Set the SHELL option -o pipefail before RUN with a pipe in it
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN GIT_TERMINAL_PROMPT=0 timeout 300 git clone https://github.com/karpathy/minGPT.git && \
+RUN GIT_TERMINAL_PROMPT=0 git clone https://github.com/karpathy/minGPT.git && \
     cd minGPT && \
     git checkout 4050db60409b5bbaaa3302cee1e49847fc145c65
 


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: The Dockerfile contained a hardcoded 300-second timeout on the `git clone` command, implemented as a preventative measure against DoS or hanging builds if the repository is inaccessible.
🎯 Impact: This is a form of "security theater." While intended to prevent infinite hangs, hardcoding timeouts for heavy, network-dependent build operations makes the build process brittle and prone to spurious failures on slower connections, without providing substantial security benefits over native CI/CD timeout configurations.
🔧 Fix: Removed the `timeout 300` wrapper from the `git clone` command in the `Dockerfile` and updated the instructional comments accordingly. Added an entry to the Sentinel journal documenting the anti-pattern of hardcoded Dockerfile build timeouts.
✅ Verification: Review the `Dockerfile` to confirm the removal. The syntax was verified using `hadolint`. A test build was initiated (though expected to fail due to sandbox constraints, the syntax itself is correct).

---
*PR created automatically by Jules for task [3046303498115189964](https://jules.google.com/task/3046303498115189964) started by @partrita*

## Summary by Sourcery

Document and remove a brittle, hardcoded Docker build timeout around the repository clone step.

Enhancements:
- Simplify the Dockerfile git clone step by relying on native CI/CD timeout handling instead of a fixed command-level timeout.

Documentation:
- Extend the Sentinel security journal with guidance on the anti-pattern of hardcoded Dockerfile build timeouts and recommended alternatives.