### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitmodules
+.jules
+.env
+minGPT/


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: Missing `.dockerignore` file exposes the entire repository directory (including `.git`, `.jules`, and the local `minGPT` submodule) to the Docker daemon during build context resolution.
🎯 Impact: This could lead to accidental leakage of sensitive host files (like `.env`, credentials, or Git history) if a `COPY . .` instruction is ever added, and it unnecessarily increases the build context size.
🔧 Fix: Created a `.dockerignore` file to explicitly exclude `.git`, `.jules`, the local `minGPT` submodule, and potential secret files from the Docker build context.
✅ Verification: Ensure the `.dockerignore` file exists and `docker build .` succeeds without sending unnecessary files to the context.

---
*PR created automatically by Jules for task [12823315506747658606](https://jules.google.com/task/12823315506747658606) started by @partrita*

## Summary by Sourcery

Enhancements:
- Exclude repository metadata, submodules, and common secret files from the Docker build context via a new .dockerignore file.