### PR TITLE
🛡️ Sentinel: [security improvement] Disable directory listing in test server

### DIFF
--- a/test_server.py
+++ b/test_server.py
@@ -1,5 +1,6 @@
 import http.server
 import socketserver
+import http
 
 class RedirectHandler(http.server.SimpleHTTPRequestHandler):
     def end_headers(self):
@@ -15,6 +16,10 @@ class RedirectHandler(http.server.SimpleHTTPRequestHandler):
             self.end_headers()
         else:
             super().do_GET()
+
+    def list_directory(self, path):
+        self.send_error(http.HTTPStatus.FORBIDDEN, "Directory listing is disabled")
+        return None
 
 with socketserver.TCPServer(("127.0.0.1", 8000), RedirectHandler) as httpd:
     httpd.serve_forever()


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The test server allows directory listing, exposing files and directories to any user navigating to a directory URL without an `index.html`.
🎯 Impact: An attacker can see the full contents of the directories served, potentially discovering sensitive information or files meant to be private.
🔧 Fix: Overrode the `list_directory` method in `SimpleHTTPRequestHandler` to return a `403 Forbidden` response instead of listing directory contents.
✅ Verification: Starting the test server and using `curl` against `http://127.0.0.1:8000/minGPT/` returns a `403` status.

---
*PR created automatically by Jules for task [1654477792117172258](https://jules.google.com/task/1654477792117172258) started by @partrita*