### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in test_server.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -25,3 +25,8 @@
 **Vulnerability:** The Dockerfile cloned a repository and did not remove the `.git` directory afterwards. This exposes the entire version history and potentially sensitive configurations or credentials that might be in the git history, unnecessarily increasing the image's attack surface and size.
 **Learning:** Even when checking out a specific commit, the `.git` directory contains the complete history and configuration. Leaving it in a built container image is poor security practice as it could be compromised.
 **Prevention:** Always remove the `.git` directory immediately after a `git clone` or `git checkout` command in the same `RUN` step in the Dockerfile using `rm -rf .git`.
+
+## 2026-04-20 - [Information Disclosure via HTTP Server]
+**Vulnerability:** The test_server.py script used Python's built-in HTTP server which, by default, serves any file in the directory including hidden files like `.git/config` and `.env`. It also leaked the Python server version in the `Server` header.
+**Learning:** Default static file servers lack the necessary configuration to prevent serving sensitive dotfiles and often leak underlying technology stack details.
+**Prevention:** Explicitly block access to paths containing `/.` by returning a 403 Forbidden error in custom request handlers, and override `server_version` and `sys_version` attributes to obscure the server implementation details.

--- a/test_server.py
+++ b/test_server.py
@@ -3,6 +3,9 @@ import socketserver
 import http
 
 class RedirectHandler(http.server.SimpleHTTPRequestHandler):
+    server_version = "SecureServer"
+    sys_version = ""
+
     def end_headers(self):
         self.send_header('X-Content-Type-Options', 'nosniff')
         self.send_header('X-Frame-Options', 'SAMEORIGIN')
@@ -10,6 +13,10 @@ class RedirectHandler(http.server.SimpleHTTPRequestHandler):
         super().end_headers()
 
     def do_GET(self):
+        if '/.' in self.path:
+            self.send_error(http.HTTPStatus.FORBIDDEN, "Access to hidden files is forbidden")
+            return
+
         if self.path == '/':
             self.send_response(302)
             self.send_header('Location', '/lab')


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Information Disclosure. The `test_server.py` script used Python's built-in HTTP server which, by default, serves any file in the directory, including sensitive hidden files like `.git/config` and `.env`. It also leaked the Python server version in the `Server` header.
🎯 **Impact:** Attackers could potentially access sensitive configurations or source history (like `.git`) or use the leaked server version for targeted exploitation.
🔧 **Fix:** Overrode `do_GET` to intercept requests containing `/.` and return an HTTP 403 Forbidden error. Overrode `server_version` and `sys_version` attributes to obscure server details in headers.
✅ **Verification:** Ran the server and tested `curl -i http://127.0.0.1:8000/.gitignore` to verify it returns a 403 Forbidden, and checked the `Server` header no longer leaks the Python version.

---
*PR created automatically by Jules for task [17245607122222367990](https://jules.google.com/task/17245607122222367990) started by @partrita*